### PR TITLE
Updated package.json to use handle

### DIFF
--- a/action-extension/package.json.liquid
+++ b/action-extension/package.json.liquid
@@ -1,6 +1,6 @@
 {%- if flavor contains "react" -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "main": "dist/main.js",
   "license": "UNLICENSED",
@@ -14,7 +14,7 @@
 }
 {%- else -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "main": "dist/main.js",
   "license": "UNLICENSED",

--- a/block-extension/package.json.liquid
+++ b/block-extension/package.json.liquid
@@ -1,6 +1,6 @@
 {%- if flavor contains "react" -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "main": "dist/main.js",
   "license": "UNLICENSED",
@@ -14,7 +14,7 @@
 }
 {%- else -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "main": "dist/main.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
### Background

The extension name property may contain invalid characters, switching to handle we ensure the package.json `name` is valid.

### Solution

Use the `handle` value as package.json `name`

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
